### PR TITLE
feat: validate text message

### DIFF
--- a/src/client/components/App.tsx
+++ b/src/client/components/App.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {withRouter, RouteComponentProps} from 'react-router-dom';
-import {Card, TextMessage, CreateRoomMessage, JoinRoomMessage, Message, NewRuleMessage, User, RuleParameters} from 'fluxxchat-protokolla';
+import {Card, TextMessage, CreateRoomMessage, JoinRoomMessage, Message, NewRuleMessage, User, RuleParameters, ValidateTextMessage} from 'fluxxchat-protokolla';
 import {MuiThemeProvider, createStyles, Theme, withStyles, WithStyles} from '@material-ui/core';
 import {get} from 'lodash';
 import themes from '../themes';
@@ -33,6 +33,7 @@ interface State {
 	turnUserId: string | null;
 	turnTime: string | null;
 	timer: number | null;
+	messageValid: boolean;
 	theme: keyof typeof themes;
 }
 
@@ -47,6 +48,7 @@ const EMPTY_STATE: State = {
 	turnUserId: null,
 	turnTime: null,
 	timer: null,
+	messageValid: true,
 	theme: 'light'
 };
 
@@ -106,6 +108,10 @@ class App extends React.Component<Props & RouteComponentProps & WithStyles<typeo
 						nickname: msg.nickname
 					});
 					this.startTurnTimer(msg.turnEndTime);
+					break;
+				case 'VALIDATE_TEXT_RESPONSE':
+					this.setState({messageValid: msg.valid});
+					break;
 				default:
 					break;
 			}
@@ -180,6 +186,16 @@ class App extends React.Component<Props & RouteComponentProps & WithStyles<typeo
 		this.setState({timer: interval});
 	}
 
+	public handleValidateMessage = (message: string) => {
+		if (this.state.connection) {
+			const protocolMessage: ValidateTextMessage = {
+				type: 'VALIDATE_TEXT',
+				textContent: message
+			};
+			this.state.connection.send(JSON.stringify(protocolMessage));
+		}
+	};
+
 	public render() {
 		// Match contains information about the matched react-router path
 		const {match, classes} = this.props;
@@ -213,6 +229,8 @@ class App extends React.Component<Props & RouteComponentProps & WithStyles<typeo
 							ownCards={ownCards}
 							onSendMessage={this.handleSendTextMessage}
 							onSendNewRule={this.handleSendNewRule}
+							onValidateMessage={this.handleValidateMessage}
+							messageValid={this.state.messageValid}
 						/>
 					)}
 				</div>

--- a/src/client/scenes/ChatRoom.tsx
+++ b/src/client/scenes/ChatRoom.tsx
@@ -142,10 +142,12 @@ class ChatRoom extends React.Component<Props, State> {
 	}
 
 	public handleSendMessage = () => {
-		const {messageDraft} = this.state;
-		this.setState({messageDraft: ''}, () => {
-			this.props.onSendMessage(messageDraft);
-		});
+		if (this.props.messageValid) {
+			const {messageDraft} = this.state;
+			this.setState({messageDraft: ''}, () => {
+				this.props.onSendMessage(messageDraft);
+			});
+		}
 	}
 
 	public handleChangeMessageDraft = (evt: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/client/scenes/ChatRoom.tsx
+++ b/src/client/scenes/ChatRoom.tsx
@@ -66,15 +66,38 @@ const styles = (theme: Theme) => createStyles({
 		flexGrow: 0,
 		alignSelf: 'center'
 	},
+	valid: {},
+	messageFieldDiv: {
+		flex: 1,
+		display: 'flex',
+		position: 'relative',
+		margin: '5px'
+	},
 	messageField: {
-		flexGrow: 1,
+		flex: 1,
 		maxHeight: '34px',
-		marginTop: '5px',
-		marginLeft: '5px',
-		marginRight: '5px',
 		height: '34px',
 		lineHeight: '34px',
-		boxSizing: 'border-box'
+		boxSizing: 'border-box',
+		':not($valid) > &': {
+			backgroundColor: '#ffee00aa'
+		}
+	},
+	messageFieldWarning: {
+		flex: '0 0 auto',
+		display: 'flex',
+		justifyContent: 'center',
+		alignItems: 'center',
+		padding: '4px 8px',
+		position: 'absolute',
+		top: 0,
+		right: 0,
+		boxSizing: 'border-box',
+		height: '100%',
+		backgroundColor: '#ff000022',
+		'$valid > &': {
+			display: 'none'
+		}
 	},
 	sendButton: {
 		width: '100px',
@@ -97,8 +120,10 @@ interface Props extends WithStyles<typeof styles> {
 	messages: Message[];
 	ownCards: Card[];
 	activeCards: Card[];
+	messageValid: boolean;
 	onSendMessage: (message: string) => void;
 	onSendNewRule: (card: Card, ruleParameters: RuleParameters) => void;
+	onValidateMessage: (message: string) => void;
 }
 
 interface State {
@@ -124,7 +149,9 @@ class ChatRoom extends React.Component<Props, State> {
 	}
 
 	public handleChangeMessageDraft = (evt: React.ChangeEvent<HTMLInputElement>) => {
-		this.setState({messageDraft: evt.target.value});
+		this.setState({messageDraft: evt.target.value}, () => {
+			this.props.onValidateMessage(this.state.messageDraft);
+		});
 	}
 
 	public handleKeyDown = (e: React.KeyboardEvent) => {
@@ -142,7 +169,7 @@ class ChatRoom extends React.Component<Props, State> {
 	}
 
 	public render() {
-		const {messages, classes} = this.props;
+		const {messages, classes, messageValid} = this.props;
 		const {messageDraft} = this.state;
 
 		return (
@@ -163,9 +190,17 @@ class ChatRoom extends React.Component<Props, State> {
 						<form onKeyDown={this.handleKeyDown}>
 							<div className={classes.inputArea}>
 								<span className={classes.messageFieldNickname}>&lt;{this.props.nickname}&gt;</span>
-								<input className={classes.messageField} type="text" value={messageDraft} onChange={this.handleChangeMessageDraft}/>
+								<div className={`${classes.messageFieldDiv} ${messageValid ? classes.valid : ''}`}>
+									<input className={classes.messageField} type="text" value={messageDraft} onChange={this.handleChangeMessageDraft}/>
+									<span className={classes.messageFieldWarning}>Invalid message</span>
+								</div>
 								<div className={classes.sendDiv}>
-									<button type="button" className={classes.sendButton} onClick={this.handleSendMessage}>
+									<button
+										type="button"
+										className={classes.sendButton}
+										onClick={this.handleSendMessage}
+										disabled={!messageValid}
+									>
 										<FormattedMessage id="room.send"/>
 									</button>
 								</div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2708,7 +2708,7 @@ flush-write-stream@^1.0.0:
 
 "fluxxchat-protokolla@git://github.com/FluxxChat/FluxxChat-protokolla.git":
   version "1.0.0"
-  resolved "git://github.com/FluxxChat/FluxxChat-protokolla.git#2df6e251a4630206ff92e74c0c4071b44ee0c2d1"
+  resolved "git://github.com/FluxxChat/FluxxChat-protokolla.git#e1286df11cbbb909127e3cc9b0b0e36288e334c5"
 
 follow-redirects@^1.0.0:
   version "1.6.1"


### PR DESCRIPTION
Ask server if currently typed chat message is valid. If not, show a warning (text field turns yellow and shows "invalid message" text) and disable send-button. Validity-queries are not rate-limited as of yet. We can add it later if/when it seems to be a problem.